### PR TITLE
path alias をやめるぞ

### DIFF
--- a/src/components/common/Card.astro
+++ b/src/components/common/Card.astro
@@ -1,8 +1,8 @@
 ---
-import WithCaption, {
-  type CaptionProps,
-} from "@/components/common/WithCaption.astro";
 import { tv, type VariantProps } from "tailwind-variants";
+
+import WithCaption, { type CaptionProps } from "../common/WithCaption.astro";
+
 export type CardProps = CaptionProps & VariantProps<typeof style>;
 
 type Props = CardProps;

--- a/src/components/common/ContentLayout.astro
+++ b/src/components/common/ContentLayout.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLAttributes } from "astro/types";
 
-import s from "@/components/common/content-layout.module.scss";
+import s from "./content-layout.module.scss";
 
 type Props = {
   asElement?: string;

--- a/src/components/element/Image.astro
+++ b/src/components/element/Image.astro
@@ -1,6 +1,7 @@
 ---
-import { declareLet } from "@/utils/declareLet";
 import { Image as AstroImage, type RemoteImageProps } from "astro:assets";
+
+import { declareLet } from "../../utils/declareLet";
 
 const MAX_WIDTH = 840;
 

--- a/src/components/element/Link.astro
+++ b/src/components/element/Link.astro
@@ -2,10 +2,11 @@
 import type { HTMLAttributes } from "astro/types";
 import type { VariantProps } from "tailwind-variants";
 
-import LinkStyle from "@/components/style/link";
-import { declareLet } from "@/utils/declareLet";
-import { isInternalLink } from "@/utils/helper";
 import { clsx } from "clsx";
+
+import { declareLet } from "../../utils/declareLet";
+import { isInternalLink } from "../../utils/helper";
+import LinkStyle from "../style/link";
 
 interface Props extends HTMLAttributes<"a"> {
   variants?: VariantProps<typeof LinkStyle>;

--- a/src/components/element/LocalImage.astro
+++ b/src/components/element/LocalImage.astro
@@ -1,6 +1,7 @@
 ---
-import { declareLet } from "@/utils/declareLet";
 import { Image as AstroImage, type LocalImageProps } from "astro:assets";
+
+import { declareLet } from "../../utils/declareLet";
 
 const MAX_WIDTH = 840;
 

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,7 +1,8 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Link from "@/components/element/Link.astro";
 import { tv } from "tailwind-variants";
+
+import ContentLayout from "../common/ContentLayout.astro";
+import Link from "../element/Link.astro";
 
 const styles = tv({
   slots: {

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,8 +1,9 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Link from "@/components/element/Link.astro";
-import NavigationMenu from "@/components/layout/NavigationMenu.astro";
 import { tv } from "tailwind-variants";
+
+import ContentLayout from "../common/ContentLayout.astro";
+import Link from "../element/Link.astro";
+import NavigationMenu from "./NavigationMenu.astro";
 
 const styles = tv({
   slots: {

--- a/src/components/layout/HistoryLayout.astro
+++ b/src/components/layout/HistoryLayout.astro
@@ -1,5 +1,5 @@
 ---
-import HistoryLayoutReact from "@/components/react/layout/HistoryLayout/HistoryLayout";
+import HistoryLayoutReact from "../react/layout/HistoryLayout/HistoryLayout";
 ---
 
 <HistoryLayoutReact client:only="react">

--- a/src/components/layout/NavigationMenu.astro
+++ b/src/components/layout/NavigationMenu.astro
@@ -1,5 +1,5 @@
 ---
-import NavMenu from "@/components/react/layout/navigation/navigationMenu";
+import NavMenu from "../react/layout/navigation/navigationMenu";
 
 const pathName = Astro.url.pathname;
 

--- a/src/components/mdx/Image.astro
+++ b/src/components/mdx/Image.astro
@@ -1,9 +1,9 @@
 ---
-import WithCaption from "@/components/common/WithCaption.astro";
+import { declareLet } from "../../utils/declareLet";
+import WithCaption from "../common/WithCaption.astro";
 import CloudinaryImage, {
   type Props as CloudinaryImageProps,
-} from "@/components/ui/CloudinaryImage.astro";
-import { declareLet } from "@/utils/declareLet";
+} from "../ui/CloudinaryImage.astro";
 
 type Props = CloudinaryImageProps;
 

--- a/src/components/mdx/Renderer.astro
+++ b/src/components/mdx/Renderer.astro
@@ -1,8 +1,8 @@
 ---
 import type { AstroComponentFactory } from "astro/runtime/server/index.js";
 
-import Link from "@/components/element/Link.astro";
-import Image from "@/components/mdx/Image.astro";
+import Link from "../element/Link.astro";
+import Image from "../mdx/Image.astro";
 
 type Props = {
   Content: AstroComponentFactory;

--- a/src/components/react/layout/HistoryLayout/HistoryLayout.tsx
+++ b/src/components/react/layout/HistoryLayout/HistoryLayout.tsx
@@ -1,7 +1,8 @@
 import type React from "react";
 
-import Clock from "@/components/react/ui/Clock";
 import { useScroll } from "framer-motion";
+
+import Clock from "../../ui/Clock";
 
 export default function HistoryLayout({
   children,

--- a/src/components/react/layout/navigation/navigationMenu.tsx
+++ b/src/components/react/layout/navigation/navigationMenu.tsx
@@ -2,9 +2,10 @@
 import type { ComponentProps } from "react";
 import type React from "react";
 
-import styles from "@/components/react/layout/navigation/styles.module.scss";
-import LinkStyle from "@/components/style/link";
 import * as NavMenu from "@radix-ui/react-navigation-menu";
+
+import LinkStyle from "../../../style/link";
+import styles from "./styles.module.scss";
 
 type NavLinkProps = {
   topPath: string;

--- a/src/components/react/ui/Clock/index.tsx
+++ b/src/components/react/ui/Clock/index.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 
-import { cn } from "@/lib/cn";
 import {
   motion,
   type MotionValue,
@@ -8,6 +7,8 @@ import {
   useTransform,
 } from "framer-motion";
 import { tv } from "tailwind-variants";
+
+import { cn } from "../../../../lib/cn";
 
 type ClockTime = {
   hour: number;

--- a/src/components/react/ui/player/index.tsx
+++ b/src/components/react/ui/player/index.tsx
@@ -1,8 +1,9 @@
 import type { YouTubeConfig } from "react-player/youtube";
 
-import { declareLet } from "@/utils/declareLet";
 import { useId } from "react";
 import ReactPlayer from "react-player";
+
+import { declareLet } from "../../../../utils/declareLet";
 
 type Props = {
   muted?: boolean;

--- a/src/components/react/ui/twitter/timelineEmbed.tsx
+++ b/src/components/react/ui/twitter/timelineEmbed.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Timeline from "@/components/react/ui/twitter/timeline";
-import useClientTheme from "@/hooks/useClientTheme";
+import useClientTheme from "../../../../hooks/useClientTheme";
+import Timeline from "./timeline";
 
 const TimelineEmbed = ({ id }: { id: string }) => {
   const { theme } = useClientTheme();

--- a/src/components/react/utils/spoiler/index.tsx
+++ b/src/components/react/utils/spoiler/index.tsx
@@ -2,9 +2,10 @@
 
 import type React from "react";
 
-import styles from "@/components/react/utils/spoiler/spoiler.module.scss";
-import { parseBoolean } from "@/utils/string";
 import { useId, useRef } from "react";
+
+import { parseBoolean } from "../../../../utils/string";
+import styles from "./spoiler.module.scss";
 
 type Props = {
   children: React.ReactNode;

--- a/src/components/ui/CloudinaryImage.astro
+++ b/src/components/ui/CloudinaryImage.astro
@@ -1,9 +1,9 @@
 ---
 import type { HTMLAttributes } from "astro/types";
 
-import Image from "@/components/element/Image.astro";
-import { cloudinaryLoader, getCloudinaryImageSize } from "@/lib/cloudinary";
-import { declareLet } from "@/utils/declareLet";
+import { cloudinaryLoader, getCloudinaryImageSize } from "../../lib/cloudinary";
+import { declareLet } from "../../utils/declareLet";
+import Image from "../element/Image.astro";
 
 type ImgProps = Omit<
   HTMLAttributes<"img">,

--- a/src/components/ui/Message.astro
+++ b/src/components/ui/Message.astro
@@ -1,10 +1,12 @@
 ---
-import type { RequiredKey } from "@/utils/@types/requiredKey";
+
 
 import Fa6SolidCircleExclamation from "~icons/fa6-solid/circle-exclamation";
 import Fa6SolidCircleInfo from "~icons/fa6-solid/circle-info";
 import Fa6SolidTriangleExclamation from "~icons/fa6-solid/triangle-exclamation";
 import { tv, type VariantProps } from "tailwind-variants";
+
+import type { RequiredKey } from "../../utils/@types/requiredKey";
 
 interface Props extends RequiredKey<VariantProps<typeof styles>, "type"> {
   title?: string | undefined;

--- a/src/components/ui/Message.astro
+++ b/src/components/ui/Message.astro
@@ -1,6 +1,4 @@
 ---
-
-
 import Fa6SolidCircleExclamation from "~icons/fa6-solid/circle-exclamation";
 import Fa6SolidCircleInfo from "~icons/fa6-solid/circle-info";
 import Fa6SolidTriangleExclamation from "~icons/fa6-solid/triangle-exclamation";

--- a/src/components/ui/PageAlert.astro
+++ b/src/components/ui/PageAlert.astro
@@ -63,7 +63,7 @@ const { backIfNewTab = "/" } = Astro.props;
       const backButton = this.querySelector(".btn-error");
       const acceptButton = this.querySelector(".btn-success");
       const content = this.querySelector("div[data-content]");
-      const backTo = this.dataset.backTo ?? "/";
+      const backTo = this.dataset["backTo"] ?? "/";
 
       dialog?.addEventListener("close", () => {
         const returnValue = dialog.returnValue;

--- a/src/components/ui/PageAlertWrapper.astro
+++ b/src/components/ui/PageAlertWrapper.astro
@@ -1,5 +1,5 @@
 ---
-import PageAlert from "@/components/ui/PageAlert.astro";
+import PageAlert from "./PageAlert.astro";
 
 type Props = {
   backIfNewTab?: string;

--- a/src/components/ui/UrlPlayer.astro
+++ b/src/components/ui/UrlPlayer.astro
@@ -1,5 +1,6 @@
 ---
-import Player from "@/components/react/ui/player";
+import Player from "../react/ui/player";
+
 interface Props {
   muted?: boolean;
   url: string;

--- a/src/components/ui/button/LinkButton.astro
+++ b/src/components/ui/button/LinkButton.astro
@@ -1,7 +1,7 @@
 ---
-import type { PropsWithoutStyle } from "@/utils/@types/propsWithoutStyle";
+import type { PropsWithoutStyle } from "../../../utils/@types/propsWithoutStyle";
 
-import ButtonStyle from "@/components/style/button";
+import ButtonStyle from "../../style/button";
 
 type Props = PropsWithoutStyle<"a", "astro">;
 

--- a/src/components/ui/card/AdventarCard.astro
+++ b/src/components/ui/card/AdventarCard.astro
@@ -1,5 +1,7 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
+import type { CardProps } from "../../common/Card.astro";
+
+import Card from "../../common/Card.astro";
 
 interface Props extends CardProps {
   id: string;

--- a/src/components/ui/card/NewUrlCard.astro
+++ b/src/components/ui/card/NewUrlCard.astro
@@ -1,12 +1,14 @@
 ---
-import type { MetaData } from "@/lib/fetchMetaData";
-
-import Card, { type CardProps } from "@/components/common/Card.astro";
-import Link from "@/components/element/Link.astro";
-import { fetchMetaData } from "@/lib/fetchMetaData";
-import { declareLet } from "@/utils/declareLet";
-import { isInternalLink } from "@/utils/helper";
 import { tv } from "tailwind-variants";
+
+import type { MetaData } from "../../../lib/fetchMetaData";
+import type { CardProps } from "../../common/Card.astro";
+
+import { fetchMetaData } from "../../../lib/fetchMetaData";
+import { declareLet } from "../../../utils/declareLet";
+import { isInternalLink } from "../../../utils/helper";
+import Card from "../../common/Card.astro";
+import Link from "../../element/Link.astro";
 
 interface Props extends CardProps {
   url: string | URL;

--- a/src/components/ui/card/PlayerCard.astro
+++ b/src/components/ui/card/PlayerCard.astro
@@ -1,6 +1,8 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
-import UrlPlayer from "@/components/ui/UrlPlayer.astro";
+import type { CardProps } from "../../common/Card.astro";
+
+import Card from "../../common/Card.astro";
+import UrlPlayer from "../UrlPlayer.astro";
 
 interface Props extends CardProps {
   muted?: boolean;

--- a/src/components/ui/card/SpotifyCard.astro
+++ b/src/components/ui/card/SpotifyCard.astro
@@ -1,6 +1,8 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
-import Spotify from "@/components/ui/Spotify.astro";
+import type { CardProps } from "../../common/Card.astro";
+
+import Card from "../../common/Card.astro";
+import Spotify from "../Spotify.astro";
 
 interface Props extends CardProps {
   shape?: "square" | "wide";

--- a/src/components/ui/card/TextCard.astro
+++ b/src/components/ui/card/TextCard.astro
@@ -1,5 +1,7 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
+import type { CardProps } from "../../common/Card.astro";
+
+import Card from "../../common/Card.astro";
 
 type Props = CardProps;
 

--- a/src/components/ui/card/TimelineCard.astro
+++ b/src/components/ui/card/TimelineCard.astro
@@ -1,6 +1,8 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
-import Timeline from "@/components/ui/twitter/Timeline.astro";
+import type { CardProps } from "../../common/Card.astro";
+
+import Card from "../../common/Card.astro";
+import Timeline from "../twitter/Timeline.astro";
 
 interface Props extends CardProps {
   id: string;

--- a/src/components/ui/card/TweetCard.astro
+++ b/src/components/ui/card/TweetCard.astro
@@ -1,6 +1,8 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
-import Tweet from "@/components/ui/twitter/Tweet.astro";
+import type { CardProps } from "../../common/Card.astro";
+
+import Card from "../../common/Card.astro";
+import Tweet from "../twitter/Tweet.astro";
 
 interface Props extends CardProps {
   id: string;

--- a/src/components/ui/card/UrlCard.astro
+++ b/src/components/ui/card/UrlCard.astro
@@ -1,10 +1,14 @@
 ---
-import Card, { type CardProps } from "@/components/common/Card.astro";
-import Link from "@/components/element/Link.astro";
-import { fetchMetaData, type MetaData } from "@/lib/fetchMetaData";
-import { declareLet } from "@/utils/declareLet";
-import { isInternalLink } from "@/utils/helper";
 import { tv } from "tailwind-variants";
+
+import type { MetaData } from "../../../lib/fetchMetaData";
+import type { CardProps } from "../../common/Card.astro";
+
+import { fetchMetaData } from "../../../lib/fetchMetaData";
+import { declareLet } from "../../../utils/declareLet";
+import { isInternalLink } from "../../../utils/helper";
+import Card from "../../common/Card.astro";
+import Link from "../../element/Link.astro";
 
 interface Props extends CardProps {
   url: string | URL;

--- a/src/components/ui/twitter/Timeline.astro
+++ b/src/components/ui/twitter/Timeline.astro
@@ -1,5 +1,6 @@
 ---
-import TimelineEmbed from "@/components/react/ui/twitter/timelineEmbed";
+import TimelineEmbed from "../../react/ui/twitter/timelineEmbed";
+
 interface Props {
   id: string;
 }

--- a/src/components/ui/twitter/Tweet.astro
+++ b/src/components/ui/twitter/Tweet.astro
@@ -1,5 +1,5 @@
 ---
-import TweetBase from "@/components/ui/twitter/TweetBase.astro";
+import TweetBase from "./TweetBase.astro";
 
 type Props = {
   id: string;

--- a/src/components/utils/SafeHTML.astro
+++ b/src/components/utils/SafeHTML.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLAttributes } from "astro/types";
 
-import { sanitizeHTML } from "@/utils/html";
+import { sanitizeHTML } from "../../utils/html";
 
 interface Props extends Omit<HTMLAttributes<"div">, "set:html"> {
   __dangerouslyDisableSanitizer?: boolean;

--- a/src/components/utils/Spoiler.astro
+++ b/src/components/utils/Spoiler.astro
@@ -1,5 +1,5 @@
 ---
-import Spoiler_ from "@/components/react/utils/spoiler";
+import Spoiler_ from "../react/utils/spoiler";
 ---
 
 <Spoiler_ client:only="react">

--- a/src/components/utils/TransitionProgress.astro
+++ b/src/components/utils/TransitionProgress.astro
@@ -1,5 +1,5 @@
 ---
-import "@/components/utils/transition-progress.css";
+import "./transition-progress.css";
 ---
 
 <div id="progress-container"></div>
@@ -15,7 +15,7 @@ import "@/components/utils/transition-progress.css";
   let intervalId: number | undefined = undefined;
 
   const startProgress = () => {
-    if (N.isStarted()) return false;
+    if (N.isStarted()) return;
 
     N.start();
     intervalId = window.setInterval(() => {

--- a/src/features/blog/components/AllTags.astro
+++ b/src/features/blog/components/AllTags.astro
@@ -1,6 +1,6 @@
 ---
-import TagLinkFlex from "@/features/blog/components/tag/TagLinkFlex.astro";
-import { getAllTags } from "@/features/blog/utils/post";
+import { getAllTags } from "../utils/post";
+import TagLinkFlex from "./tag/TagLinkFlex.astro";
 
 const allTags = await getAllTags();
 ---

--- a/src/features/blog/components/BlogFrontMatter.astro
+++ b/src/features/blog/components/BlogFrontMatter.astro
@@ -2,20 +2,20 @@
 import type { CollectionEntry } from "astro:content";
 import type { ReadTimeResults } from "reading-time";
 
-import Link from "@/components/element/Link.astro";
-import CloudinaryImage from "@/components/ui/CloudinaryImage.astro";
-import Message from "@/components/ui/Message.astro";
-import TagLinkFlex from "@/features/blog/components/tag/TagLinkFlex.astro";
-import { getPostOgpImage } from "@/features/blog/utils/post";
-import { declareLet } from "@/utils/declareLet";
-import { roundReadTime } from "@/utils/markdown";
-import { trimExtension } from "@/utils/string";
 import Fa6SolidArrowsRotate from "~icons/fa6-solid/arrows-rotate";
 import Fa6SolidCalendar from "~icons/fa6-solid/calendar";
 import Fa6SolidClock from "~icons/fa6-solid/clock";
 import { tv } from "tailwind-variants";
 
+import Link from "../../../components/element/Link.astro";
+import CloudinaryImage from "../../../components/ui/CloudinaryImage.astro";
+import Message from "../../../components/ui/Message.astro";
 import { formatInJst, replaceUtcWithJst } from "../../../lib/date";
+import { declareLet } from "../../../utils/declareLet";
+import { roundReadTime } from "../../../utils/markdown";
+import { trimExtension } from "../../../utils/string";
+import { getPostOgpImage } from "../utils/post";
+import TagLinkFlex from "./tag/TagLinkFlex.astro";
 
 type Props = {
   entry: CollectionEntry<"posts">;

--- a/src/features/blog/components/BlogPostCard.astro
+++ b/src/features/blog/components/BlogPostCard.astro
@@ -1,12 +1,12 @@
 ---
 import type { CollectionEntry } from "astro:content";
 
-import Link from "@/components/element/Link.astro";
-import CloudinaryImage from "@/components/ui/CloudinaryImage.astro";
-import { trimExtension } from "@/utils/string";
 import { tv } from "tailwind-variants";
 
+import Link from "../../../components/element/Link.astro";
+import CloudinaryImage from "../../../components/ui/CloudinaryImage.astro";
 import { formatInJst, replaceUtcWithJst } from "../../../lib/date";
+import { trimExtension } from "../../../utils/string";
 
 type Props = {
   post: CollectionEntry<"posts">;

--- a/src/features/blog/components/BlogRenderer.astro
+++ b/src/features/blog/components/BlogRenderer.astro
@@ -2,8 +2,8 @@
 import type { MarkdownHeading } from "astro";
 import type { AstroComponentFactory } from "astro/runtime/server/index.js";
 
-import Renderer from "@/components/mdx/Renderer.astro";
-import Toc from "@/features/blog/components/Toc.astro";
+import Renderer from "../../../components/mdx/Renderer.astro";
+import Toc from "./Toc.astro";
 
 type Props = {
   Content: AstroComponentFactory;

--- a/src/features/blog/components/BlogStyle.astro
+++ b/src/features/blog/components/BlogStyle.astro
@@ -1,5 +1,5 @@
 ---
-import s from "@/features/blog/components/blog-article.module.scss";
+import s from "./blog-article.module.scss";
 
 type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 

--- a/src/features/blog/components/Toc.astro
+++ b/src/features/blog/components/Toc.astro
@@ -1,8 +1,9 @@
 ---
 import type { MarkdownHeading } from "astro";
 
-import Link from "@/components/element/Link.astro";
 import { tv } from "tailwind-variants";
+
+import Link from "../../../components/element/Link.astro";
 
 type Props = {
   depth: number;

--- a/src/features/blog/components/tag/TagLink.astro
+++ b/src/features/blog/components/tag/TagLink.astro
@@ -1,5 +1,5 @@
 ---
-import Link from "@/components/element/Link.astro";
+import Link from "../../../../components/element/Link.astro";
 
 type Props = {
   tag: string;

--- a/src/features/blog/components/tag/TagLinkFlex.astro
+++ b/src/features/blog/components/tag/TagLinkFlex.astro
@@ -1,5 +1,5 @@
 ---
-import TagLink from "@/features/blog/components/tag/TagLink.astro";
+import TagLink from "./TagLink.astro";
 
 type Props = {
   tags: string[];

--- a/src/features/blog/utils/post.ts
+++ b/src/features/blog/utils/post.ts
@@ -1,8 +1,9 @@
-import type { TrimExtension } from "@/utils/string";
-
-import { declareLet } from "@/utils/declareLet";
 import { type CollectionEntry, getCollection } from "astro:content";
 import { SHOW_DRAFT_POST } from "astro:env/server";
+
+import type { TrimExtension } from "../../../utils/string";
+
+import { declareLet } from "../../../utils/declareLet";
 
 type sortAction = (
   a: CollectionEntry<"posts">,

--- a/src/features/meta/BaseHead.astro
+++ b/src/features/meta/BaseHead.astro
@@ -1,12 +1,12 @@
 ---
 import "@unocss/reset/tailwind.css";
+import "katex/dist/katex.min.css";
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
-import "@/styles/gfm-footnote.scss";
-import "@/styles/globals.scss";
-import "@/styles/code.scss";
+import "../../styles/gfm-footnote.scss";
+import "../../styles/globals.scss";
+import "../../styles/code.scss";
 import { ViewTransitions } from "astro:transitions";
-import "katex/dist/katex.min.css";
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 

--- a/src/features/meta/BlogPostSEO.astro
+++ b/src/features/meta/BlogPostSEO.astro
@@ -1,11 +1,11 @@
 ---
 import type { CollectionEntry } from "astro:content";
 
-import { getPostOgpImage } from "@/features/blog/utils/post";
-import { trimExtension } from "@/utils/string";
 import { SEO } from "astro-seo";
 
 import { replaceUtcWithJst } from "../../lib/date";
+import { trimExtension } from "../../utils/string";
+import { getPostOgpImage } from "../blog/utils/post";
 
 type Props = {
   entry: CollectionEntry<"posts">;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,9 +1,9 @@
 ---
-import type { Props as HeadProps } from "@/features/meta/BaseHead.astro";
+import type { Props as HeadProps } from "../features/meta/BaseHead.astro";
 
-import Footer from "@/components/layout/Footer.astro";
-import Header from "@/components/layout/Header.astro";
-import BaseHead from "@/features/meta/BaseHead.astro";
+import Footer from "../components/layout/Footer.astro";
+import Header from "../components/layout/Header.astro";
+import BaseHead from "../features/meta/BaseHead.astro";
 
 type Props = HeadProps;
 

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,6 +1,6 @@
 ---
-import TransitionProgress from "@/components/utils/TransitionProgress.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
+import TransitionProgress from "../components/utils/TransitionProgress.astro";
+import BaseLayout from "./BaseLayout.astro";
 ---
 
 {/* temporary disable ViewTransitions: maybe buggy in latest chrome */}

--- a/src/lib/cloudinary/client.ts
+++ b/src/lib/cloudinary/client.ts
@@ -1,10 +1,11 @@
-import { extractAndDecodePublicId } from "@/lib/cloudinary";
 import {
   CLOUDINARY_API_KEY,
   CLOUDINARY_API_SECRET,
   CLOUDINARY_CLOUD_NAME,
 } from "astro:env/server";
 import { v2 as cloudinaryV2 } from "cloudinary";
+
+import { extractAndDecodePublicId } from "./extract";
 
 type CloudinaryCredentials = {
   api_key: string;

--- a/src/lib/cloudinary/extract.ts
+++ b/src/lib/cloudinary/extract.ts
@@ -1,4 +1,4 @@
-import { CLOUDINARY_URL } from "@/lib/cloudinary";
+import { CLOUDINARY_URL } from ".";
 
 /**
  *  Extract public id from cloudinary url.

--- a/src/lib/cloudinary/loader.ts
+++ b/src/lib/cloudinary/loader.ts
@@ -1,4 +1,4 @@
-import { extractPublicId } from "@/lib/cloudinary";
+import { extractPublicId } from "./extract";
 
 type ImageLoaderOption = {
   blur?: boolean;

--- a/src/lib/cloudinary/size.ts
+++ b/src/lib/cloudinary/size.ts
@@ -1,4 +1,4 @@
-import { getCloudinary } from "@/lib/cloudinary";
+import { getCloudinary } from "./client";
 
 const IMAGE_SIZE_CACHE = new Map<string, { height: number; width: number }>();
 

--- a/src/lib/fetchMetaData.ts
+++ b/src/lib/fetchMetaData.ts
@@ -1,5 +1,6 @@
-import { declareLet } from "@/utils/declareLet";
 import ogs from "open-graph-scraper-lite";
+
+import { declareLet } from "../utils/declareLet";
 
 type ImageData = {
   alt: string | undefined;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,11 +1,12 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Footer from "@/components/layout/Footer.astro";
-import Header from "@/components/layout/Header.astro";
-import LinkButton from "@/components/ui/button/LinkButton.astro";
-import BaseHead from "@/features/meta/BaseHead.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
 import Fa6RegularFaceSadTear from "~icons/fa6-regular/face-sad-tear";
+
+import ContentLayout from "../components/common/ContentLayout.astro";
+import Footer from "../components/layout/Footer.astro";
+import Header from "../components/layout/Header.astro";
+import LinkButton from "../components/ui/button/LinkButton.astro";
+import BaseHead from "../features/meta/BaseHead.astro";
+import BaseSEO from "../features/meta/BaseSEO.astro";
 ---
 
 <html lang="ja">

--- a/src/pages/about/_sns.astro
+++ b/src/pages/about/_sns.astro
@@ -1,8 +1,9 @@
 ---
-import Link from "@/components/element/Link.astro";
 import Fa6BrandsGithub from "~icons/fa6-brands/github";
 import Fa6BrandsXTwitter from "~icons/fa6-brands/x-twitter";
 import Fa6RegularEnvelope from "~icons/fa6-regular/envelope";
+
+import Link from "../../components/element/Link.astro";
 ---
 
 <div class="grid grid-cols-2 gap-2 md:grid-cols-4">

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,12 +1,12 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import MDXRenderer from "@/components/mdx/Renderer.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
-import AboutContent from "@/pages/about/_about.mdx";
-import CodeContent from "@/pages/about/_code.mdx";
-import SNS from "@/pages/about/_sns.astro";
+import ContentLayout from "../../components/common/ContentLayout.astro";
+import Renderer from "../../components/mdx/Renderer.astro";
+import BlogStyle from "../../features/blog/components/BlogStyle.astro";
+import BaseSEO from "../../features/meta/BaseSEO.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import AboutContent from "./_about.mdx";
+import CodeContent from "./_code.mdx";
+import SNS from "./_sns.astro";
 ---
 
 <BaseLayout>
@@ -14,13 +14,13 @@ import SNS from "@/pages/about/_sns.astro";
   <ContentLayout>
     <BlogStyle colorHeading={["h2"]}>
       <h1>About me</h1>
-      <MDXRenderer Content={CodeContent} />
+      <Renderer Content={CodeContent} />
       <SNS />
       <div>
         <p>インターネットの片隅で音楽を聴いて生きています。</p>
         <p>2022年からプログラミングも始めました。</p>
       </div>
-      <MDXRenderer Content={AboutContent} />
+      <Renderer Content={AboutContent} />
     </BlogStyle>
   </ContentLayout>
 </BaseLayout>

--- a/src/pages/api/blog/[...slug].ts
+++ b/src/pages/api/blog/[...slug].ts
@@ -1,9 +1,11 @@
-import type { TrimExtension } from "@/utils/string";
 import type { APIRoute } from "astro";
 
-import { getAllPosts, getAllPreviewPosts } from "@/features/blog/utils/post";
-import { trimExtension } from "@/utils/string";
 import { type CollectionEntry, getEntry } from "astro:content";
+
+import type { TrimExtension } from "../../../utils/string";
+
+import { getAllPosts, getAllPreviewPosts } from "../../../features/blog/utils/post";
+import { trimExtension } from "../../../utils/string";
 
 export async function getStaticPaths() {
   const blogEntries = await getAllPosts();

--- a/src/pages/api/blog/[...slug].ts
+++ b/src/pages/api/blog/[...slug].ts
@@ -4,7 +4,10 @@ import { type CollectionEntry, getEntry } from "astro:content";
 
 import type { TrimExtension } from "../../../utils/string";
 
-import { getAllPosts, getAllPreviewPosts } from "../../../features/blog/utils/post";
+import {
+  getAllPosts,
+  getAllPreviewPosts,
+} from "../../../features/blog/utils/post";
 import { trimExtension } from "../../../utils/string";
 
 export async function getStaticPaths() {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,11 +1,12 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import AllTags from "@/features/blog/components/AllTags.astro";
-import BlogPostCard from "@/features/blog/components/BlogPostCard.astro";
-import { getAllPosts } from "@/features/blog/utils/post";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BlogLayout from "@/layouts/BlogLayout.astro";
 import { fade } from "astro:transitions";
+
+import ContentLayout from "../../components/common/ContentLayout.astro";
+import AllTags from "../../features/blog/components/AllTags.astro";
+import BlogPostCard from "../../features/blog/components/BlogPostCard.astro";
+import { getAllPosts } from "../../features/blog/utils/post";
+import BaseSEO from "../../features/meta/BaseSEO.astro";
+import BlogLayout from "../../layouts/BlogLayout.astro";
 
 const posts = await getAllPosts({
   sortAction: (a, b) => {

--- a/src/pages/blog/og-image/[...slug].png.ts
+++ b/src/pages/blog/og-image/[...slug].png.ts
@@ -1,10 +1,12 @@
-import type { TrimExtension } from "@/utils/string";
 import type { APIRoute } from "astro";
 
-import { getAllPosts } from "@/features/blog/utils/post";
-import { getBlogOGImage } from "@/pages/blog/og-image/_getImage";
-import { trimExtension } from "@/utils/string";
 import { type CollectionEntry, getEntry } from "astro:content";
+
+import type { TrimExtension } from "../../../utils/string";
+
+import { getAllPosts } from "../../../features/blog/utils/post";
+import { trimExtension } from "../../../utils/string";
+import { getBlogOGImage } from "./_getImage";
 
 export async function getStaticPaths() {
   const blogEntries = await getAllPosts();

--- a/src/pages/blog/post/[...slug].astro
+++ b/src/pages/blog/post/[...slug].astro
@@ -2,18 +2,19 @@
 import type { CollectionEntry } from "astro:content";
 import type { ReadTimeResults } from "reading-time";
 
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import PageAlertWrapper from "@/components/ui/PageAlertWrapper.astro";
-import SafeHTML from "@/components/utils/SafeHTML.astro";
-import BlogFrontMatter from "@/features/blog/components/BlogFrontMatter.astro";
-import BlogRenderer from "@/features/blog/components/BlogRenderer.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import { getAllPosts } from "@/features/blog/utils/post";
-import BlogPostSEO from "@/features/meta/BlogPostSEO.astro";
-import BlogLayout from "@/layouts/BlogLayout.astro";
-import { parseMarkdownArray } from "@/utils/markdown";
-import { trimExtension } from "@/utils/string";
 import { render } from "astro:content";
+
+import ContentLayout from "../../../components/common/ContentLayout.astro";
+import PageAlertWrapper from "../../../components/ui/PageAlertWrapper.astro";
+import SafeHTML from "../../../components/utils/SafeHTML.astro";
+import BlogFrontMatter from "../../../features/blog/components/BlogFrontMatter.astro";
+import BlogRenderer from "../../../features/blog/components/BlogRenderer.astro";
+import BlogStyle from "../../../features/blog/components/BlogStyle.astro";
+import { getAllPosts } from "../../../features/blog/utils/post";
+import BlogPostSEO from "../../../features/meta/BlogPostSEO.astro";
+import BlogLayout from "../../../layouts/BlogLayout.astro";
+import { parseMarkdownArray } from "../../../utils/markdown";
+import { trimExtension } from "../../../utils/string";
 
 export async function getStaticPaths() {
   const blogEntries = await getAllPosts();
@@ -32,7 +33,7 @@ const renderResult = await render(entry);
 
 const showAlert = (entry.data.alert && entry.data.alert.length > 0) ?? false;
 
-const readTime = renderResult.remarkPluginFrontmatter.minutesRead as
+const readTime = renderResult.remarkPluginFrontmatter["minutesRead"] as
   | ReadTimeResults
   | undefined;
 const alerts = entry.data.alert ?? [];

--- a/src/pages/blog/preview/[...slug].astro
+++ b/src/pages/blog/preview/[...slug].astro
@@ -2,18 +2,19 @@
 import type { CollectionEntry } from "astro:content";
 import type { ReadTimeResults } from "reading-time";
 
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import PageAlertWrapper from "@/components/ui/PageAlertWrapper.astro";
-import SafeHTML from "@/components/utils/SafeHTML.astro";
-import BlogFrontMatter from "@/features/blog/components/BlogFrontMatter.astro";
-import BlogRenderer from "@/features/blog/components/BlogRenderer.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import { getAllPreviewPosts } from "@/features/blog/utils/post";
-import BlogPostSEO from "@/features/meta/BlogPostSEO.astro";
-import BlogLayout from "@/layouts/BlogLayout.astro";
-import { parseMarkdownArray } from "@/utils/markdown";
-import { trimExtension } from "@/utils/string";
 import { render } from "astro:content";
+
+import ContentLayout from "../../../components/common/ContentLayout.astro";
+import PageAlertWrapper from "../../../components/ui/PageAlertWrapper.astro";
+import SafeHTML from "../../../components/utils/SafeHTML.astro";
+import BlogFrontMatter from "../../../features/blog/components/BlogFrontMatter.astro";
+import BlogRenderer from "../../../features/blog/components/BlogRenderer.astro";
+import BlogStyle from "../../../features/blog/components/BlogStyle.astro";
+import { getAllPreviewPosts } from "../../../features/blog/utils/post";
+import BlogPostSEO from "../../../features/meta/BlogPostSEO.astro";
+import BlogLayout from "../../../layouts/BlogLayout.astro";
+import { parseMarkdownArray } from "../../../utils/markdown";
+import { trimExtension } from "../../../utils/string";
 
 export async function getStaticPaths() {
   const previewEntries = await getAllPreviewPosts();
@@ -32,7 +33,7 @@ const renderResult = await render(entry);
 
 const showAlert = (entry.data.alert && entry.data.alert.length > 0) ?? false;
 
-const readTime = renderResult.remarkPluginFrontmatter.minutesRead as
+const readTime = renderResult.remarkPluginFrontmatter["minutesRead"] as
   | ReadTimeResults
   | undefined;
 const alerts = entry.data.alert ?? [];

--- a/src/pages/blog/rss.xml.ts
+++ b/src/pages/blog/rss.xml.ts
@@ -1,9 +1,10 @@
 import type { APIRoute } from "astro";
 
-import { SITE_URL } from "@/consts";
-import { getAllPosts } from "@/features/blog/utils/post";
-import { trimExtension } from "@/utils/string";
 import rss from "@astrojs/rss";
+
+import { SITE_URL } from "../../consts";
+import { getAllPosts } from "../../features/blog/utils/post";
+import { trimExtension } from "../../utils/string";
 
 export const GET: APIRoute = async () => {
   const posts = await getAllPosts();

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,11 +1,12 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import AllTags from "@/features/blog/components/AllTags.astro";
-import BlogPostCard from "@/features/blog/components/BlogPostCard.astro";
-import { getAllTags, getPostsByTags } from "@/features/blog/utils/post";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BlogLayout from "@/layouts/BlogLayout.astro";
 import { fade } from "astro:transitions";
+
+import ContentLayout from "../../../components/common/ContentLayout.astro";
+import AllTags from "../../../features/blog/components/AllTags.astro";
+import BlogPostCard from "../../../features/blog/components/BlogPostCard.astro";
+import { getAllTags, getPostsByTags } from "../../../features/blog/utils/post";
+import BaseSEO from "../../../features/meta/BaseSEO.astro";
+import BlogLayout from "../../../layouts/BlogLayout.astro";
 
 export async function getStaticPaths() {
   const tags = await getAllTags();

--- a/src/pages/dlc.astro
+++ b/src/pages/dlc.astro
@@ -1,9 +1,9 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Link from "@/components/element/Link.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
+import ContentLayout from "../components/common/ContentLayout.astro";
+import Link from "../components/element/Link.astro";
+import BlogStyle from "../features/blog/components/BlogStyle.astro";
+import BaseSEO from "../features/meta/BaseSEO.astro";
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>

--- a/src/pages/history/index.astro
+++ b/src/pages/history/index.astro
@@ -1,10 +1,10 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Link from "@/components/element/Link.astro";
-import HistoryLayout from "@/components/layout/HistoryLayout.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
+import ContentLayout from "../../components/common/ContentLayout.astro";
+import Link from "../../components/element/Link.astro";
+import HistoryLayout from "../../components/layout/HistoryLayout.astro";
+import BlogStyle from "../../features/blog/components/BlogStyle.astro";
+import BaseSEO from "../../features/meta/BaseSEO.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,9 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Link from "@/components/element/Link.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
+import ContentLayout from "../components/common/ContentLayout.astro";
+import Link from "../components/element/Link.astro";
+import BlogStyle from "../features/blog/components/BlogStyle.astro";
+import BaseSEO from "../features/meta/BaseSEO.astro";
+import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>

--- a/src/pages/legal/privacy.astro
+++ b/src/pages/legal/privacy.astro
@@ -1,10 +1,10 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Renderer from "@/components/mdx/Renderer.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
-import Content from "@/pages/legal/_privacy.mdx";
+import ContentLayout from "../../components/common/ContentLayout.astro";
+import Renderer from "../../components/mdx/Renderer.astro";
+import BlogStyle from "../../features/blog/components/BlogStyle.astro";
+import BaseSEO from "../../features/meta/BaseSEO.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Content from "./_privacy.mdx";
 ---
 
 <BaseLayout>

--- a/src/pages/portfolio/_experience.astro
+++ b/src/pages/portfolio/_experience.astro
@@ -1,7 +1,7 @@
 ---
-import type { Experience } from "@/pages/portfolio/_data";
-
 import { tv } from "tailwind-variants";
+
+import type { Experience } from "./_data";
 
 type Props = {
   experience: Experience;

--- a/src/pages/portfolio/_work.astro
+++ b/src/pages/portfolio/_work.astro
@@ -1,6 +1,7 @@
 ---
-import Link from "@/components/element/Link.astro";
 import { tv } from "tailwind-variants";
+
+import Link from "../../components/element/Link.astro";
 type Props = {
   description?: string;
   repoUrl?: string;

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -1,16 +1,16 @@
 ---
-import ContentLayout from "@/components/common/ContentLayout.astro";
-import Link from "@/components/element/Link.astro";
-import LocalImage from "@/components/element/LocalImage.astro";
-import UrlCard from "@/components/ui/card/UrlCard.astro";
-import BlogStyle from "@/features/blog/components/BlogStyle.astro";
-import BaseSEO from "@/features/meta/BaseSEO.astro";
-import BaseLayout from "@/layouts/BaseLayout.astro";
-import { EXPERIENCES } from "@/pages/portfolio/_data";
-import Experience from "@/pages/portfolio/_experience.astro";
-import ExperienceWrapper from "@/pages/portfolio/_experienceWrapper.astro";
-import SkillsSvg from "@/pages/portfolio/_skills.svg";
-import Work from "@/pages/portfolio/_work.astro";
+import ContentLayout from "../../components/common/ContentLayout.astro";
+import Link from "../../components/element/Link.astro";
+import LocalImage from "../../components/element/LocalImage.astro";
+import UrlCard from "../../components/ui/card/UrlCard.astro";
+import BlogStyle from "../../features/blog/components/BlogStyle.astro";
+import BaseSEO from "../../features/meta/BaseSEO.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { EXPERIENCES } from "./_data";
+import Experience from "./_experience.astro";
+import ExperienceWrapper from "./_experienceWrapper.astro";
+import SkillsSvg from "./_skills.svg";
+import Work from "./_work.astro";
 ---
 
 <BaseLayout>

--- a/src/utils/declareLet.test.ts
+++ b/src/utils/declareLet.test.ts
@@ -1,4 +1,4 @@
-import { declareLet } from "@/utils/declareLet";
+import { declareLet } from "./declareLet";
 
 test("declare let", () => {
   expect(

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,8 +1,9 @@
 import type { ReadTimeResults } from "reading-time";
 
-import { declareLet } from "@/utils/declareLet";
-import { roundToNearestMultiple } from "@/utils/number";
 import { marked } from "marked";
+
+import { declareLet } from "./declareLet";
+import { roundToNearestMultiple } from "./number";
 
 async function parseMarkdown(markdown: string) {
   return await marked(markdown, { async: true });

--- a/src/utils/number.test.ts
+++ b/src/utils/number.test.ts
@@ -1,4 +1,4 @@
-import { roundToNearestMultiple, zeroPadding } from "@/utils/number";
+import { roundToNearestMultiple, zeroPadding } from "./number";
 
 test("zeroPadding with single digit number", () => {
   expect(zeroPadding(5, 3)).toBe("005");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,6 @@
 {
   "extends": "@virtual-live-lab/tsconfig/astro",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"],
-      "@public/*": ["./public/*"],
-      "@root/*": ["./*"]
-    },
     "types": ["vitest/globals", "unplugin-icons/types/astro"]
   },
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,7 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   test: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
     globals: true,
   },
 });


### PR DESCRIPTION
<!-- テンプレートなので、適宜項目や内容をいじってください -->

## やりたいこと

TypeScript の import alias をやめて素朴に relative path を書く

## やったこと

素直に path を書き換え
## やらなかったこと

<!-- このPRに関連するが保留したことや、検討した結果行わなかったことを理由とともに書く -->

##
## 補足

<!-- その他PRに関連する共有など -->
